### PR TITLE
feat(version9): add ArianeeProductCertificate schema with durabilityIndex

### DIFF
--- a/public/version9/ArianeeProductCertificate-i18n.json
+++ b/public/version9/ArianeeProductCertificate-i18n.json
@@ -1,0 +1,2389 @@
+{
+  "$id": "https://cert.arianee.org/version9/ArianeeProductCertificate-i18n.json",
+  "$schema": "https://cert.arianee.org/version9/ArianeeProductCertificate-i18n.json",
+  "title": "Arianee Certificate i18n (transparency and composed & thread)",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "title": "$schema",
+      "type": "string",
+      "default": "https://cert.arianee.org/version9/ArianeeProductCertificate-i18n.json",
+      "description": "Arianee Certificate i18n (transparency and composed)"
+    },
+    "language": {
+      "type": "string",
+      "title": "Language",
+      "description": "Descriptions and external contents can be stored in different languages",
+      "oneOf": [
+        {
+          "title": "French",
+          "description": "French",
+          "enum": ["fr-FR"]
+        },
+        {
+          "title": "English (US)",
+          "description": "English (US)",
+          "enum": ["en-US"]
+        },
+        {
+          "title": "Chinese (traditional)",
+          "description": "Chinese (traditional)",
+          "enum": ["zh-TW"]
+        },
+        {
+          "title": "Chinese (simplified)",
+          "description": "Chinese (simplified)",
+          "enum": ["zh-CN"]
+        },
+        {
+          "enum": ["ko-KR"],
+          "title": "Korean",
+          "description": "Korean"
+        },
+        {
+          "enum": ["ja-JP"],
+          "title": "Japanese",
+          "description": "Japanese"
+        },
+        {
+          "enum": ["de-DE"],
+          "title": "German",
+          "description": "German"
+        },
+        {
+          "enum": ["es"],
+          "title": "Spanish",
+          "description": "Spanish"
+        },
+        {
+          "enum": ["it"],
+          "title": "Italian",
+          "description": "Italian"
+        },
+        {
+          "enum": ["ru"],
+          "title": "Russian",
+          "description": "Russian"
+        }
+      ]
+    },
+    "name": {
+      "type": "string",
+      "title": "Name",
+      "default": "",
+      "description": "Name of the product.\n Likely to be the first thing displayed on a wallet app."
+    },
+    "sku": {
+      "type": "string",
+      "title": "SKU",
+      "default": "",
+      "description": "The stock keeping unit (SKU) is an alphanumeric code assigned to a product by a business to identify the price, product options and manufacturer of the merchandise."
+    },
+    "gtin": {
+      "type": "string",
+      "title": "GTIN",
+      "default": "",
+      "description": "The Global Trade Item Number (GTIN) is a globally unique 14-digit number used to identify trade items, products, or services. GTIN is also an umbrella term that refers to the entire family of UCC. EAN data structures. The entire family of data structures within the GTIN is: GTIN-12 (UPC)."
+    },
+    "brandInternalId": {
+      "type": "string",
+      "title": "Brand Internal ID",
+      "default": "",
+      "description": "Identification number that end customers will not have access to."
+    },
+    "category": {
+      "type": "string",
+      "title": "Category",
+      "description": "Information on the broad category the product belongs to."
+    },
+    "subCategory": {
+      "type": "string",
+      "title": "Sub Category",
+      "description": "Information on the specific category the product belongs to."
+    },
+    "intended": {
+      "type": "string",
+      "title": "Intended",
+      "description": "Information on the target customer market of the product.",
+      "oneOf": [
+        {
+          "description": "Women's",
+          "title": "Women's",
+          "enum": ["womens"]
+        },
+        {
+          "description": "Men's",
+          "title": "Men's",
+          "enum": ["mens"]
+        },
+        {
+          "description": "Adult Gender Neutral",
+          "title": "Adult Gender Neutral",
+          "enum": ["neutral"]
+        }
+      ]
+    },
+    "serialnumber": {
+      "type": "array",
+      "title": "Serial Number",
+      "description": "Identification numbers that end customers will have access to.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "title": "Type",
+            "oneOf": [
+              {
+                "description": "Serial Number",
+                "title": "Serial Number",
+                "enum": ["serialnumber"]
+              },
+              {
+                "description": "Case Number",
+                "title": "Case Number",
+                "enum": ["casenumber"]
+              },
+              {
+                "description": "Movement Number",
+                "title": "Movement Number",
+                "enum": ["movementnumber"]
+              },
+              {
+                "description": "Vehicle Identification Number",
+                "title": "Vehicle Identification Number",
+                "enum": ["vin"]
+              },
+              {
+                "description": "Poinçon de Genève",
+                "title": "Poinçon de Genève",
+                "enum": ["pgeneve"]
+              },
+              {
+                "description": "Millesimation",
+                "title": "Millesimation",
+                "enum": ["millesimation"]
+              }
+            ]
+          },
+          "value": {
+            "type": "string",
+            "title": "Value"
+          }
+        }
+      }
+    },
+    "subBrand": {
+      "type": "string",
+      "title": "Sub Brand",
+      "description": "This field may be used when a product is part of a sub Brand owned by the Brand who creates the certificate."
+    },
+    "model": {
+      "type": "string",
+      "title": "Model",
+      "description": "Model of the product to bring precisions to the Name.\n Likely to be the second thing displayed on a wallet app."
+    },
+    "description": {
+      "type": "string",
+      "title": "Description",
+      "description": "Description of the product. (HTML Accepted)\n A description can be stored for each language"
+    },
+    "subDescription": {
+      "type": "array",
+      "title": "Description (more)",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "title": "Type",
+            "oneOf": [
+              {
+                "enum": ["service"],
+                "title": "Servicing",
+                "description": "Servicing"
+              },
+              {
+                "enum": ["recycling"],
+                "title": "Recycling",
+                "description": "Recycling"
+              },
+              {
+                "enum": ["other"],
+                "title": "other",
+                "description": "other"
+              }
+            ]
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "content": {
+            "type": "string",
+            "title": "Content"
+          },
+          "order": {
+            "type": "number",
+            "title": "Order (number)"
+          }
+        }
+      }
+    },
+    "externalContents": {
+      "description": "This field is designed to store the links to external contents the Brand whish to introduce to the end customer in a wallet app.\n Specific external contents can be stored for each language.",
+      "type": "array",
+      "title": "External Contents",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "title": "Type",
+            "oneOf": [
+              {
+                "enum": ["website"],
+                "title": "Website (main)",
+                "description": "Regular link"
+              },
+              {
+                "enum": ["originalProductPage"],
+                "title": "Original Product Page",
+                "description": "Link to the original product page on the brand's website"
+              },
+              {
+                "enum": ["proofLinkAction"],
+                "title": "proofLinkAction",
+                "description": "Link with a proof of ownership. The difference with arianeeAccessTokenAuthLink is that proofLinkAction does need blockchain transaction. It is not instant but can be revoked."
+              },
+              {
+                "enum": ["transparency"],
+                "title": "transparency",
+                "description": "Url of transparency events json"
+              },
+              {
+                "enum": ["arianeeAccessTokenAuthLink"],
+                "title": "arianeeAccessTokenAuthLink",
+                "description": "Link with a Arianee Access Token, proof of ownership. The difference with proofLinkAction is that arianeeAccessTokenAuthLink does not need blockchain transaction. It is instant but cannnot be revoked. However it does expire."
+              },
+              {
+                "enum": ["youtube"],
+                "title": "Youtube video",
+                "description": "Youtube video"
+              },
+              {
+                "enum": ["authRedirectTo"],
+                "title": "Authentified One 2 Many",
+                "description": "Link to redirect to a another claimaible nft. NFT should redirect to the same link with Arianee access token"
+              },
+              {
+                "enum": ["userManual"],
+                "title": "User manual",
+                "description": "Link to user manual"
+              }
+            ]
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "url": {
+            "type": "string",
+            "title": "Url"
+          },
+          "order": {
+            "type": "number",
+            "title": "Order (number)"
+          }
+        }
+      }
+    },
+    "msrp": {
+      "type": "array",
+      "title": "Manufacturers suggested retail price",
+      "description": "The manufacturer's suggested retail price (MSRP) is the price a product's producer recommends it be sold for in retail stores. MSRP Country should respect ISO 3166 alpha-3",
+      "items": {
+        "type": "object",
+        "properties": {
+          "msrp": {
+            "type": "string",
+            "title": "MSRP",
+            "default": "",
+            "description": "Manufacturers suggested retail price (number)"
+          },
+          "currency": {
+            "type": "string",
+            "title": "Currency",
+            "default": "",
+            "description": "Currency",
+            "oneOf": [
+              {
+                "title": "US Dollar",
+                "description": "US Dollar",
+                "enum": ["USD"]
+              },
+              {
+                "title": "Euro",
+                "description": "Euro",
+                "enum": ["EUR"]
+              },
+              {
+                "title": "Pound",
+                "description": "Pound",
+                "enum": ["GBP"]
+              }
+            ]
+          },
+          "msrpCountry": {
+            "type": "string",
+            "title": "Country (msrp)",
+            "default": "",
+            "description": "Country of Intended Original Sale (ISO 3166 alpha-3)"
+          }
+        }
+      }
+    },
+    "medias": {
+      "type": "array",
+      "title": "Medias",
+      "description": "Picture & media used to support the presentation of the product in the wallet app.  (ideally .png with transparent background and square, less than 1mo)",
+      "items": {
+        "type": "object",
+        "properties": {
+          "mediaType": {
+            "type": "string",
+            "title": "Media Type",
+            "oneOf": [
+              {
+                "enum": ["picture"],
+                "title": "Picture (png / jpg)",
+                "description": "Picture (png / jpg)"
+              },
+              {
+                "enum": ["youtube"],
+                "title": "Youtube video",
+                "description": "Youtube video"
+              },
+              {
+                "enum": ["3dModel"],
+                "title": "3D Model",
+                "description": "A 3D Model (glb / gltf)"
+              },
+              {
+                "enum": ["video"],
+                "title": "Video",
+                "description": "A video (mp4)"
+              },
+              {
+                "enum": ["AR"],
+                "title": "Augmented Reality",
+                "description": "Augmented reality content"
+              }
+            ]
+          },
+          "type": {
+            "type": "string",
+            "title": "Type",
+            "oneOf": [
+              {
+                "enum": ["product"],
+                "title": "Product media / picture",
+                "description": "used to support the presentation of the product in the wallet app.  (ideally .png with transparent background and square, less than 1mo)"
+              },
+              {
+                "enum": ["brandItemBackgroundPicture"],
+                "title": "Brand Item Background Picture (3200x1900) ratioed",
+                "description": "(3200x1900), format : jpg/png, max 400ko created for the certificate in the list of certificates someone has. It should include a product picture."
+              },
+              {
+                "enum": ["itemBackgroundPicture"],
+                "title": "Item Background Picture (3000x3000) ratioed",
+                "description": "dark, format .jpg, (3000x3000) max 400ko created for the background of the certificate screen"
+              },
+              {
+                "enum": ["certificateBackgroundPicture"],
+                "title": "Certificate Background Picture (1900x3200 TBD) preferably dark - with logo on top",
+                "description": "dark, no logo, format .jpg, (1900x3200), max 400ko created for the background of the transfer/proof of certificate screens"
+              },
+              {
+                "enum": ["3dModelPreview"],
+                "title": "3D model preview image, displayed in the media list in the wallet application",
+                "description": "[3D model / 1] Preview image (ideally .png of the model in idle state)"
+              },
+              {
+                "enum": ["3dModelAsset"],
+                "title": "3D model asset, rendered in the wallet application",
+                "description": "[3D model / 2] Model file (.glb, .gltf, can contain animations), requires [3D Model / 1] to be set right before"
+              },
+              {
+                "enum": ["videoPreview"],
+                "title": "Video preview image, displayed in the media list in the wallet application",
+                "description": "[Video / 1] Preview image (ideally .png of a frame of the video)"
+              },
+              {
+                "enum": ["videoSource"],
+                "title": "Video source, played in the wallet application",
+                "description": "[Video / 2] Video source (.mp4), requires [Video / 1] to be set right before"
+              },
+              {
+                "enum": ["ARPreview"],
+                "title": "Augmented Reality preview",
+                "description": "[Augmented Reality preview] used to support the presentation of the AR asset in the wallet app.  (ideally .png with transparent background and square, less than 1mo)"
+              },
+              {
+                "enum": ["ARAsset"],
+                "title": "Augmented Reality asset",
+                "description": "[Augmented Reality asset] AR asset file (USDZ)"
+              },
+              {
+                "enum": ["ARPrimaryAsset"],
+                "title": "Augmented Reality Primay asset",
+                "description": "[Augmented Reality Primay asset] AR asset file (USDZ)"
+              }
+            ]
+          },
+          "url": {
+            "type": "string",
+            "title": "URL"
+          },
+          "hash": {
+            "type": "string",
+            "title": "Media Hash"
+          },
+          "order": {
+            "type": "number",
+            "title": "Media Order (number)"
+          }
+        }
+      }
+    },
+    "customAttributes": {
+      "type": "array",
+      "title": "Custom attributes",
+      "description": "Information on the specific attributes of the product.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "title": "Type"
+          },
+          "value": {
+            "type": "string",
+            "title": "Value"
+          }
+        }
+      }
+    },
+    "attributes": {
+      "type": "array",
+      "title": "Attributes",
+      "description": "Information on the specific attributes of the product that are aimed to be shared with partners.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "trait_type": {
+            "type": "string",
+            "title": "Trait Type (for external service like opensea)"
+          },
+          "type": {
+            "type": "string",
+            "title": "Type",
+            "oneOf": [
+              {
+                "title": "Color",
+                "description": "Color",
+                "enum": ["color"]
+              },
+              {
+                "title": "Printed",
+                "description": "Printed",
+                "enum": ["printed"]
+              },
+              {
+                "title": "Complication",
+                "description": "Complication",
+                "enum": ["complication"]
+              }
+            ]
+          },
+          "value": {
+            "type": "string",
+            "title": "Value"
+          }
+        }
+      }
+    },
+    "materials": {
+      "type": "array",
+      "title": "Materials",
+      "description": "Information on the materials used to manufacture the product.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "material": {
+            "type": "string",
+            "title": "Material",
+            "oneOf": [
+              {
+                "title": "Cashmere",
+                "description": "Cashmere",
+                "enum": ["cashmere"]
+              },
+              {
+                "title": "Cotton",
+                "description": "Cotton",
+                "enum": ["cotton"]
+              },
+              {
+                "title": "Denim - Jeans",
+                "description": "Denim - Jeans",
+                "enum": ["denim-jeans"]
+              },
+              {
+                "title": "Gold",
+                "description": "Gold",
+                "enum": ["gold"]
+              },
+              {
+                "title": "Silver",
+                "description": "Silver",
+                "enum": ["silver"]
+              }
+            ]
+          },
+          "value": {
+            "type": "string",
+            "title": "Value"
+          },
+          "pourcentage": {
+            "type": "string",
+            "title": "Pourcentage",
+            "description": "Pourcentage without % (numeric)"
+          }
+        }
+      }
+    },
+    "size": {
+      "type": "array",
+      "title": "Sizes",
+      "description": "Information on the size of the product.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "title": "Type",
+            "oneOf": [
+              {
+                "title": "Weight",
+                "description": "Weight",
+                "enum": ["weight"]
+              },
+              {
+                "title": "Height",
+                "description": "Height",
+                "enum": ["height"]
+              },
+              {
+                "title": "Width",
+                "description": "Width",
+                "enum": ["width"]
+              },
+              {
+                "title": "Depth",
+                "description": "Depth",
+                "enum": ["depth"]
+              },
+              {
+                "title": "Size",
+                "description": "Size",
+                "enum": ["size"]
+              }
+            ]
+          },
+          "value": {
+            "type": "string",
+            "title": "Value"
+          },
+          "unit": {
+            "type": "string",
+            "title": "Unit",
+            "oneOf": [
+              {
+                "title": "Inch",
+                "description": "Inch",
+                "enum": ["in"]
+              },
+              {
+                "title": "Centimer",
+                "description": "Centimer",
+                "enum": ["cm"]
+              },
+              {
+                "title": "Millimeter",
+                "description": "Millimeter",
+                "enum": ["mm"]
+              },
+              {
+                "title": "EU",
+                "description": "EU",
+                "enum": ["eu"]
+              },
+              {
+                "title": "UK",
+                "description": "UK",
+                "enum": ["uk"]
+              },
+              {
+                "title": "US",
+                "description": "US",
+                "enum": ["us"]
+              },
+              {
+                "title": "Kilogram",
+                "description": "Kilogram",
+                "enum": ["kg"]
+              },
+              {
+                "title": "Pound",
+                "description": "Pound",
+                "enum": ["lb"]
+              }
+            ]
+          }
+        }
+      }
+    },
+    "manufacturingCountry": {
+      "type": "string",
+      "title": "Country (manufacturing)",
+      "default": "",
+      "description": "Country of manufacture in final assembly stage. (ISO 3166 alpha-3)"
+    },
+    "manufacturer": {
+      "type": "string",
+      "title": "Manufacturer",
+      "default": "",
+      "description": "Manufacturer name in final assembly stage"
+    },
+    "facilityId": {
+      "type": "string",
+      "title": "Facility Identification number",
+      "default": "",
+      "description": "Facility Identification in Open Apparel Registry (OAR) or GS1 database"
+    },
+    "productCertification": {
+      "type": "array",
+      "title": "Product Certifications & Compliance",
+      "description": "Certifications a Brand owns at the product level. \nIt is currently an information not verified and the Brand bares all responsibilities related to its affiliation to a certification. ",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name",
+            "oneOf": [
+              {
+                "title": "Fair Trade",
+                "description": "Fair Trade",
+                "enum": ["fairtrade"]
+              },
+              {
+                "title": "WWF",
+                "description": "WWF",
+                "enum": ["wwf"]
+              }
+            ]
+          }
+        }
+      }
+    },
+    "transparencyItems": {
+      "type": "array",
+      "title": "Transparency information about product",
+      "description": "Transparency information regarding the product",
+      "items": {
+        "type": "object",
+        "properties": {
+          "category": {
+            "type": "string",
+            "title": "Category of transparency",
+            "oneOf": [
+              {
+                "title": "material",
+                "description": "material",
+                "enum": ["material"]
+              },
+              {
+                "title": "assembly",
+                "description": "assembly",
+                "enum": ["assembly"]
+              },
+              {
+                "title": "impact",
+                "description": "impact",
+                "enum": ["impact"]
+              }
+            ]
+          },
+          "type": {
+            "type": "string",
+            "title": "Type of transparency",
+            "oneOf": [
+              {
+                "title": "responsible_procurement",
+                "description": "responsible_procurement",
+                "enum": ["responsible_procurement"]
+              },
+              {
+                "title": "eco_design",
+                "description": "eco_design",
+                "enum": ["eco_design"]
+              },
+              {
+                "title": "packaging",
+                "description": "packaging",
+                "enum": ["packaging"]
+              }
+            ]
+          },
+          "subtype": {
+            "type": "string",
+            "title": "Subtype of transparency",
+            "oneOf": [
+              {
+                "title": "material-responsible_procurement-ethical_purchasing",
+                "description": "material-responsible_procurement-ethical_purchasing",
+                "enum": ["material-responsible_procurement-ethical_purchasing"]
+              },
+              {
+                "title": "material-responsible_procurement-organic organic",
+                "description": "material-responsible_procurement-organic organic",
+                "enum": ["material-responsible_procurement-organic organic"]
+              }
+            ]
+          },
+          "title": {
+            "type": "string",
+            "title": "Title to be displayed"
+          },
+          "subtitle": {
+            "type": "string",
+            "title": "Subtitle to be displayed"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description",
+            "description": "Description of the product. (HTML Accepted)\n A description can be stored for each language"
+          },
+          "medias": {
+            "type": "array",
+            "title": "Medias",
+            "description": "Picture & media used to support the presentation of the product in the wallet app.  (ideally .png with transparent background and square, less than 1mo)",
+            "items": {
+              "type": "object",
+              "properties": {
+                "mediaType": {
+                  "type": "string",
+                  "title": "Media Type",
+                  "oneOf": [
+                    {
+                      "enum": ["picture"],
+                      "title": "Picture (png / jpg)",
+                      "description": "Picture (png / jpg)"
+                    },
+                    {
+                      "enum": ["youtube"],
+                      "title": "Youtube video",
+                      "description": "Youtube video"
+                    }
+                  ]
+                },
+                "type": {
+                  "type": "string",
+                  "title": "Type",
+                  "oneOf": [
+                    {
+                      "enum": ["icon"],
+                      "title": "icon of label",
+                      "description": "An icon depicting the transparency item (png transparent)"
+                    },
+                    {
+                      "enum": ["transparencyPicture"],
+                      "title": "Transparency picture",
+                      "description": "A picture depicting the transparency item"
+                    }
+                  ]
+                },
+                "url": {
+                  "type": "string",
+                  "title": "URL"
+                },
+                "hash": {
+                  "type": "string",
+                  "title": "Media Hash"
+                },
+                "order": {
+                  "type": "number",
+                  "title": "Media Order (number)"
+                }
+              }
+            }
+          },
+          "externalContents": {
+            "description": "This field is designed to store the links to external contents the Brand whish to introduce to the end customer in a wallet app.\n Specific external contents can be stored for each language.",
+            "type": "array",
+            "title": "External Contents",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "title": "Type",
+                  "oneOf": [
+                    {
+                      "enum": ["website"],
+                      "title": "Website (main)",
+                      "description": "Regular link"
+                    },
+                    {
+                      "enum": ["proofLinkAction"],
+                      "title": "proofLinkAction",
+                      "description": "Link with a proof of ownership. The difference with arianeeAccessTokenAuthLink is that proofLinkAction does need blockchain transaction. It is not instant but can be revoked."
+                    },
+                    {
+                      "enum": ["transparency"],
+                      "title": "transparency",
+                      "description": "Url of transparency events json"
+                    },
+                    {
+                      "enum": ["arianeeAccessTokenAuthLink"],
+                      "title": "arianeeAccessTokenAuthLink",
+                      "description": "Link with a Arianee Access Token, proof of ownership. The difference with proofLinkAction is that arianeeAccessTokenAuthLink does not need blockchain transaction. It is instant but cannnot be revoked. However it does expire."
+                    },
+                    {
+                      "enum": ["youtube"],
+                      "title": "Youtube video",
+                      "description": "Youtube video"
+                    }
+                  ]
+                },
+                "title": {
+                  "type": "string",
+                  "title": "Title"
+                },
+                "url": {
+                  "type": "string",
+                  "title": "Url"
+                },
+                "order": {
+                  "type": "number",
+                  "title": "Order (number)"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "i18n": {
+      "type": "array",
+      "title": "Other languages :  description / external contents",
+      "items": {
+        "type": "object",
+        "properties": {
+          "language": {
+            "type": "string",
+            "title": "Language",
+            "oneOf": [
+              {
+                "description": "French",
+                "title": "French",
+                "enum": ["fr-FR"]
+              },
+              {
+                "description": "English (US)",
+                "title": "English (US)",
+                "enum": ["en-US"]
+              },
+              {
+                "description": "Chinese (traditional)",
+                "title": "Chinese (traditional)",
+                "enum": ["zh-TW"]
+              },
+              {
+                "description": "Chinese (simplified)",
+                "title": "Chinese (simplified)",
+                "enum": ["zh-CN"]
+              },
+              {
+                "enum": ["ko-KR"],
+                "title": "Korean",
+                "description": "Korean"
+              },
+              {
+                "enum": ["ja-JP"],
+                "title": "Japanese",
+                "description": "Japanese"
+              },
+              {
+                "enum": ["de-DE"],
+                "title": "German",
+                "description": "German"
+              },
+              {
+                "enum": ["es"],
+                "title": "Spanish",
+                "description": "Spanish"
+              },
+              {
+                "enum": ["it"],
+                "title": "Italian",
+                "description": "Italian"
+              },
+              {
+                "enum": ["ru"],
+                "title": "Russian",
+                "description": "Russian"
+              }
+            ]
+          },
+          "name": {
+            "type": "string",
+            "title": "Name",
+            "default": "",
+            "description": "Name of the product.\n Likely to be the first thing displayed on a wallet app."
+          },
+          "model": {
+            "type": "string",
+            "title": "Model",
+            "description": "Model of the product to bring precisions to the Name.\n Likely to be the second thing displayed on a wallet app."
+          },
+          "subBrand": {
+            "type": "string",
+            "title": "Sub Brand",
+            "description": "This field may be used when a product is part of a sub Brand owned by the Brand who creates the certificate."
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
+          "subDescription": {
+            "type": "array",
+            "title": "Description (more)",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "title": "Type",
+                  "oneOf": [
+                    {
+                      "enum": ["service"],
+                      "title": "Servicing",
+                      "description": "Servicing"
+                    },
+                    {
+                      "enum": ["recycling"],
+                      "title": "Recycling",
+                      "description": "Recycling"
+                    },
+                    {
+                      "enum": ["other"],
+                      "title": "other",
+                      "description": "other"
+                    }
+                  ]
+                },
+                "title": {
+                  "type": "string",
+                  "title": "Title"
+                },
+                "content": {
+                  "type": "string",
+                  "title": "Content"
+                },
+                "order": {
+                  "type": "number",
+                  "title": "Order (number)"
+                }
+              }
+            }
+          },
+          "medias": {
+            "type": "array",
+            "title": "Medias",
+            "description": "Picture & media used to support the presentation of the product in the wallet app.  (ideally .png with transparent background and square, less than 1mo)",
+            "items": {
+              "type": "object",
+              "properties": {
+                "mediaType": {
+                  "type": "string",
+                  "title": "Media Type",
+                  "oneOf": [
+                    {
+                      "enum": ["picture"],
+                      "title": "Picture (png / jpg)",
+                      "description": "Picture (png / jpg)"
+                    },
+                    {
+                      "enum": ["youtube"],
+                      "title": "Youtube video",
+                      "description": "Youtube video"
+                    },
+                    {
+                      "enum": ["3dModel"],
+                      "title": "3D Model",
+                      "description": "A 3D Model (glb / gltf)"
+                    },
+                    {
+                      "enum": ["video"],
+                      "title": "Video",
+                      "description": "A video (mp4)"
+                    },
+                    {
+                      "enum": ["AR"],
+                      "title": "Augmented Reality",
+                      "description": "Augmented reality content"
+                    }
+                  ]
+                },
+                "type": {
+                  "type": "string",
+                  "title": "Type",
+                  "oneOf": [
+                    {
+                      "enum": ["product"],
+                      "title": "Product media / picture",
+                      "description": "used to support the presentation of the product in the wallet app.  (ideally .png with transparent background and square, less than 1mo)"
+                    },
+                    {
+                      "enum": ["brandItemBackgroundPicture"],
+                      "title": "Brand Item Background Picture (3200x1900) ratioed",
+                      "description": "(3200x1900), format : jpg/png, max 400ko created for the certificate in the list of certificates someone has. It should include a product picture."
+                    },
+                    {
+                      "enum": ["itemBackgroundPicture"],
+                      "title": "Item Background Picture (3000x3000) ratioed",
+                      "description": "dark, format .jpg, (3000x3000) max 400ko created for the background of the certificate screen"
+                    },
+                    {
+                      "enum": ["certificateBackgroundPicture"],
+                      "title": "Certificate Background Picture (1900x3200 TBD) preferably dark - with logo on top",
+                      "description": "dark, no logo, format .jpg, (1900x3200), max 400ko created for the background of the transfer/proof of certificate screens"
+                    },
+                    {
+                      "enum": ["3dModelPreview"],
+                      "title": "3D model preview image, displayed in the media list in the wallet application",
+                      "description": "[3D model / 1] Preview image (ideally .png of the model in idle state)"
+                    },
+                    {
+                      "enum": ["3dModelAsset"],
+                      "title": "3D model asset, rendered in the wallet application",
+                      "description": "[3D model / 2] Model file (.glb, .gltf, can contain animations), requires [3D Model / 1] to be set right before"
+                    },
+                    {
+                      "enum": ["videoPreview"],
+                      "title": "Video preview image, displayed in the media list in the wallet application",
+                      "description": "[Video / 1] Preview image (ideally .png of a frame of the video)"
+                    },
+                    {
+                      "enum": ["videoSource"],
+                      "title": "Video source, played in the wallet application",
+                      "description": "[Video / 2] Video source (.mp4), requires [Video / 1] to be set right before"
+                    },
+                    {
+                      "enum": ["ARPreview"],
+                      "title": "Augmented Reality preview",
+                      "description": "[Augmented Reality preview] used to support the presentation of the AR asset in the wallet app.  (ideally .png with transparent background and square, less than 1mo)"
+                    },
+                    {
+                      "enum": ["ARAsset"],
+                      "title": "Augmented Reality asset",
+                      "description": "[Augmented Reality asset] AR asset file (USDZ)"
+                    },
+                    {
+                      "enum": ["ARPrimaryAsset"],
+                      "title": "Augmented Reality Primay asset",
+                      "description": "[Augmented Reality Primay asset] AR asset file (USDZ)"
+                    }
+                  ]
+                },
+                "url": {
+                  "type": "string",
+                  "title": "URL"
+                },
+                "hash": {
+                  "type": "string",
+                  "title": "Media Hash"
+                },
+                "order": {
+                  "type": "number",
+                  "title": "Media Order (number)"
+                }
+              }
+            }
+          },
+          "externalContents": {
+            "type": "array",
+            "title": "External Contents",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "title": "Type",
+                  "oneOf": [
+                    {
+                      "enum": ["website"],
+                      "title": "Website (main)",
+                      "description": "Regular link"
+                    },
+                    {
+                      "enum": ["proofLinkAction"],
+                      "title": "proofLinkAction",
+                      "description": "Link with a proof of ownership. The difference with arianeeAccessTokenAuthLink is that proofLinkAction does need blockchain transaction. It is not instant but can be revoked."
+                    },
+                    {
+                      "enum": ["arianeeAccessTokenAuthLink"],
+                      "title": "arianeeAccessTokenAuthLink",
+                      "description": "Link with a Arianee Access Token, proof of ownership. The difference with proofLinkAction is that arianeeAccessTokenAuthLink does not need blockchain transaction. It is instant but cannnot be revoked. However it does expire."
+                    },
+                    {
+                      "enum": ["youtube"],
+                      "title": "Youtube video",
+                      "description": "Youtube video"
+                    },
+                    {
+                      "enum": ["authRedirectTo"],
+                      "title": "Authentified One 2 Many",
+                      "description": "Link to redirect to a another claimaible nft. NFT should redirect to the same link with Arianee access token"
+                    },
+                    {
+                      "enum": ["userManual"],
+                      "title": "User manual",
+                      "description": "Link to user manual"
+                    }
+                  ]
+                },
+                "title": {
+                  "type": "string",
+                  "title": "Title"
+                },
+                "url": {
+                  "type": "string",
+                  "title": "Url"
+                },
+                "order": {
+                  "type": "number",
+                  "title": "Order (number)"
+                }
+              }
+            }
+          },
+          "customAttributes": {
+            "type": "array",
+            "title": "Custom attributes",
+            "description": "Information on the specific attributes of the product.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "title": "Type"
+                },
+                "value": {
+                  "type": "string",
+                  "title": "Value"
+                }
+              }
+            }
+          },
+          "transparencyItems": {
+            "type": "array",
+            "title": "Transparency information about product",
+            "description": "Transparency information regarding the product",
+            "items": {
+              "type": "object",
+              "properties": {
+                "category": {
+                  "type": "string",
+                  "title": "Category of transparency",
+                  "oneOf": [
+                    {
+                      "title": "material",
+                      "description": "material",
+                      "enum": ["material"]
+                    },
+                    {
+                      "title": "assembly",
+                      "description": "assembly",
+                      "enum": ["assembly"]
+                    },
+                    {
+                      "title": "impact",
+                      "description": "impact",
+                      "enum": ["impact"]
+                    }
+                  ]
+                },
+                "type": {
+                  "type": "string",
+                  "title": "Type of transparency",
+                  "oneOf": [
+                    {
+                      "title": "responsible_procurement",
+                      "description": "responsible_procurement",
+                      "enum": ["responsible_procurement"]
+                    },
+                    {
+                      "title": "eco_design",
+                      "description": "eco_design",
+                      "enum": ["eco_design"]
+                    },
+                    {
+                      "title": "packaging",
+                      "description": "packaging",
+                      "enum": ["packaging"]
+                    }
+                  ]
+                },
+                "subtype": {
+                  "type": "string",
+                  "title": "Subtype of transparency",
+                  "oneOf": [
+                    {
+                      "title": "material-responsible_procurement-ethical_purchasing",
+                      "description": "material-responsible_procurement-ethical_purchasing",
+                      "enum": ["material-responsible_procurement-ethical_purchasing"]
+                    },
+                    {
+                      "title": "material-responsible_procurement-organic organic",
+                      "description": "material-responsible_procurement-organic organic",
+                      "enum": ["material-responsible_procurement-organic organic"]
+                    }
+                  ]
+                },
+                "title": {
+                  "type": "string",
+                  "title": "Title to be displayed"
+                },
+                "subtitle": {
+                  "type": "string",
+                  "title": "Subtitle to be displayed"
+                },
+                "description": {
+                  "type": "string",
+                  "title": "Description",
+                  "description": "Description of the product. (HTML Accepted)\n A description can be stored for each language"
+                },
+                "medias": {
+                  "type": "array",
+                  "title": "Medias",
+                  "description": "Picture & media used to support the presentation of the product in the wallet app.  (ideally .png with transparent background and square, less than 1mo)",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "mediaType": {
+                        "type": "string",
+                        "title": "Media Type",
+                        "oneOf": [
+                          {
+                            "enum": ["picture"],
+                            "title": "Picture (png / jpg)",
+                            "description": "Picture (png / jpg)"
+                          },
+                          {
+                            "enum": ["youtube"],
+                            "title": "Youtube video",
+                            "description": "Youtube video"
+                          }
+                        ]
+                      },
+                      "type": {
+                        "type": "string",
+                        "title": "Type",
+                        "oneOf": [
+                          {
+                            "enum": ["icon"],
+                            "title": "icon of label",
+                            "description": "An icon depicting the transparency item (png transparent)"
+                          },
+                          {
+                            "enum": ["transparencyPicture"],
+                            "title": "Transparency picture",
+                            "description": "A picture depicting the transparency item"
+                          }
+                        ]
+                      },
+                      "url": {
+                        "type": "string",
+                        "title": "URL"
+                      },
+                      "hash": {
+                        "type": "string",
+                        "title": "Media Hash"
+                      },
+                      "order": {
+                        "type": "number",
+                        "title": "Media Order (number)"
+                      }
+                    }
+                  }
+                },
+                "externalContents": {
+                  "description": "This field is designed to store the links to external contents the Brand whish to introduce to the end customer in a wallet app.\n Specific external contents can be stored for each language.",
+                  "type": "array",
+                  "title": "External Contents",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "title": "Type",
+                        "oneOf": [
+                          {
+                            "enum": ["website"],
+                            "title": "Website (main)",
+                            "description": "Regular link"
+                          },
+                          {
+                            "enum": ["proofLinkAction"],
+                            "title": "proofLinkAction",
+                            "description": "Link with a proof of ownership. The difference with arianeeAccessTokenAuthLink is that proofLinkAction does need blockchain transaction. It is not instant but can be revoked."
+                          },
+                          {
+                            "enum": ["transparency"],
+                            "title": "transparency",
+                            "description": "Url of transparency events json"
+                          },
+                          {
+                            "enum": ["arianeeAccessTokenAuthLink"],
+                            "title": "arianeeAccessTokenAuthLink",
+                            "description": "Link with a Arianee Access Token, proof of ownership. The difference with proofLinkAction is that arianeeAccessTokenAuthLink does not need blockchain transaction. It is instant but cannnot be revoked. However it does expire."
+                          },
+                          {
+                            "enum": ["youtube"],
+                            "title": "Youtube video",
+                            "description": "Youtube video"
+                          }
+                        ]
+                      },
+                      "title": {
+                        "type": "string",
+                        "title": "Title"
+                      },
+                      "url": {
+                        "type": "string",
+                        "title": "Url"
+                      },
+                      "order": {
+                        "type": "number",
+                        "title": "Order (number)"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "parentCertificates": {
+      "description": "This field is designed to store the links to parent certificates.",
+      "type": "array",
+      "title": "Parent Certificates",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "title": "Type",
+            "oneOf": [
+              {
+                "enum": ["full"],
+                "title": "Full",
+                "description": "Full"
+              }
+            ]
+          },
+          "arianeeLink": {
+            "type": "string",
+            "title": "Url"
+          },
+          "order": {
+            "type": "number",
+            "title": "Order (number)"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "string",
+      "title": "Image (for external services like OpenSea)",
+      "default": "",
+      "description": "Image for external services."
+    },
+    "image_data": {
+      "type": "string",
+      "title": "Raw SVG image data (for external services like OpenSea)",
+      "default": "",
+      "description": "Raw SVG image data for external services."
+    },
+    "external_url": {
+      "type": "string",
+      "title": "External URL (for external services like OpenSea)",
+      "default": "",
+      "description": "External URL for external services."
+    },
+    "background_color": {
+      "type": "string",
+      "title": "background_color (for external services like OpenSea)",
+      "default": "",
+      "description": "background_color for external services."
+    },
+    "animation_url": {
+      "type": "string",
+      "title": "animation_url (for external services like OpenSea)",
+      "default": "",
+      "description": "animation_url for external services."
+    },
+    "youtube_url": {
+      "type": "string",
+      "title": "youtube_url (for external services like OpenSea)",
+      "default": "",
+      "description": "youtube_url for external services."
+    },
+    "thread": {
+      "type": "array",
+      "title": "Thread",
+      "description": "This attribute will encapsulate a sequence of references, each representing an NFT residing on distinct blockchains. This attribute will be in the content of the DPPs associated with both the POA network and the Polygon Supernet.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "origin": {
+            "type": "object",
+            "properties": {
+              "protocolName": {
+                "type": "string",
+                "title": "Protocol Name"
+              },
+              "tokenId": {
+                "type": "number",
+                "title": "Token ID"
+              },
+              "chainId": {
+                "type": "number",
+                "title": "Chain ID"
+              },
+              "smartContractAddress": {
+                "type": "string",
+                "title": "Smart Contract Address"
+              }
+            }
+          },
+          "destination": {
+            "type": "object",
+            "properties": {
+              "protocolName": {
+                "type": "string",
+                "title": "Protocol Name"
+              },
+              "tokenId": {
+                "type": "number",
+                "title": "Token ID"
+              },
+              "chainId": {
+                "type": "number",
+                "title": "Chain ID"
+              },
+              "smartContractAddress": {
+                "type": "string",
+                "title": "Smart Contract Address"
+              }
+            }
+          },
+          "events": {
+            "type": "object",
+            "properties": {
+              "hydrate": {
+                "type": "object",
+                "properties": {
+                  "address": {
+                    "type": "string",
+                    "title": "Address"
+                  },
+                  "blockNumber": {
+                    "type": "number",
+                    "title": "Block Number"
+                  },
+                  "transactionHash": {
+                    "type": "string",
+                    "title": "Transaction Hash"
+                  },
+                  "transactionIndex": {
+                    "type": "number",
+                    "title": "Transaction Index"
+                  },
+                  "blockHash": {
+                    "type": "string",
+                    "title": "Block Hash"
+                  },
+                  "logIndex": {
+                    "type": "number",
+                    "title": "Log Index"
+                  },
+                  "removed": {
+                    "type": "boolean",
+                    "title": "Removed"
+                  },
+                  "id": {
+                    "type": "string",
+                    "title": "ID"
+                  },
+                  "returnValues": {
+                    "type": "object",
+                    "properties": {
+                      "_tokenId": {
+                        "type": "string",
+                        "title": "Token ID"
+                      },
+                      "_imprint": {
+                        "type": "string",
+                        "title": "Imprint"
+                      },
+                      "_uri": {
+                        "type": "string",
+                        "title": "URI"
+                      },
+                      "_initialKey": {
+                        "type": "string",
+                        "title": "Initial Key"
+                      },
+                      "_tokenRecoveryTimestamp": {
+                        "type": "string",
+                        "title": "Token Recovery Timestamp"
+                      },
+                      "_initialKeyIsRequestKey": {
+                        "type": "boolean",
+                        "title": "Initial Key Is Request Key"
+                      },
+                      "_tokenCreation": {
+                        "type": "string",
+                        "title": "Token Creation"
+                      }
+                    }
+                  },
+                  "event": {
+                    "type": "string",
+                    "title": "Event"
+                  },
+                  "signature": {
+                    "type": "string",
+                    "title": "Signature"
+                  },
+                  "raw": {
+                    "type": "object",
+                    "properties": {
+                      "data": {
+                        "type": "string",
+                        "title": "Data"
+                      },
+                      "topics": {
+                        "type": "array",
+                        "title": "Topics",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "transfers": {
+                "type": "array",
+                "title": "Transfers",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "address": {
+                      "type": "string",
+                      "title": "Address"
+                    },
+                    "blockNumber": {
+                      "type": "number",
+                      "title": "Block Number"
+                    },
+                    "transactionHash": {
+                      "type": "string",
+                      "title": "Transaction Hash"
+                    },
+                    "transactionIndex": {
+                      "type": "number",
+                      "title": "Transaction Index"
+                    },
+                    "blockHash": {
+                      "type": "string",
+                      "title": "Block Hash"
+                    },
+                    "logIndex": {
+                      "type": "number",
+                      "title": "Log Index"
+                    },
+                    "removed": {
+                      "type": "boolean",
+                      "title": "Removed"
+                    },
+                    "id": {
+                      "type": "string",
+                      "title": "ID"
+                    },
+                    "returnValues": {
+                      "type": "object",
+                      "properties": {
+                        "_from": {
+                          "type": "string",
+                          "title": "From"
+                        },
+                        "_to": {
+                          "type": "string",
+                          "title": "To"
+                        },
+                        "_tokenId": {
+                          "type": "string",
+                          "title": "Token ID"
+                        }
+                      }
+                    },
+                    "event": {
+                      "type": "string",
+                      "title": "Event"
+                    },
+                    "signature": {
+                      "type": "string",
+                      "title": "Signature"
+                    },
+                    "raw": {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "string",
+                          "title": "Data"
+                        },
+                        "topics": {
+                          "type": "array",
+                          "title": "Topics",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "arianeeEvents": {
+                "type": "array",
+                "title": "Arianee Events",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "content": {
+                      "type": "object",
+                      "properties": {
+                        "$schema": {
+                          "title": "$schema",
+                          "type": "string",
+                          "default": "https://cert.arianee.org/version1/ArianeeEvent-i18n.json",
+                          "widget": "hidden"
+                        },
+                        "eventType": {
+                          "type": "string",
+                          "title": "Type",
+                          "description": "The type of Event.",
+                          "widget": {
+                            "id": "select"
+                          },
+                          "oneOf": [
+                            {
+                              "title": "Service",
+                              "description": "Service - usually issued by customer support.",
+                              "enum": ["service"]
+                            },
+                            {
+                              "title": "Auction",
+                              "description": "Auction - usually issued when a financial transaction and a transfer of certificate are involved.",
+                              "enum": ["auction"]
+                            },
+                            {
+                              "title": "Initial Sale",
+                              "description": "Initial Sale - usually issued for the initial sale.",
+                              "enum": ["initialSale"]
+                            },
+                            {
+                              "title": "Warranty",
+                              "description": "Warranty - usually issued when a warranty is attached to the product.",
+                              "enum": ["warranty"]
+                            },
+                            {
+                              "title": "Resell",
+                              "description": "Resell - usually issued when a resell event occurs.",
+                              "enum": ["resell"]
+                            },
+                            {
+                              "title": "Repair",
+                              "description": "Repair - usually issued when the product is repaired.",
+                              "enum": ["repair"]
+                            },
+                             {
+                              "title": "Refurbished",
+                              "description": "Refurbished - the product has been restored to a like-new condition.",
+                              "enum": ["refurbished"]
+                            },
+                            {
+                              "title": "Experience",
+                              "description": "Experience - usually issued when an experienced happens around the product.",
+                              "enum": ["experience"]
+                            }
+                          ]
+                        },
+                        "language": {
+                          "type": "string",
+                          "title": "Default Language",
+                          "widget": {
+                            "id": "select"
+                          },
+                          "oneOf": [
+                            {
+                              "enum": ["fr-FR"],
+                              "title": "French",
+                              "description": "French"
+                            },
+                            {
+                              "enum": ["en-US"],
+                              "title": "English (US)",
+                              "description": "English (US)"
+                            },
+                            {
+                              "enum": ["zh-TW"],
+                              "title": "Chinese (traditional)",
+                              "description": "Chinese (traditional)"
+                            },
+                            {
+                              "enum": ["zh-CN"],
+                              "title": "Chinese (simplified)",
+                              "description": "Chinese (simplified)"
+                            },
+                            {
+                              "enum": ["ko-KR"],
+                              "title": "Korean",
+                              "description": "Korean"
+                            },
+                            {
+                              "enum": ["ja-JP"],
+                              "title": "Japanese",
+                              "description": "Japanese"
+                            },
+                            {
+                              "enum": ["de-DE"],
+                              "title": "German",
+                              "description": "German"
+                            },
+                            {
+                              "enum": ["es"],
+                              "title": "Spanish",
+                              "description": "Spanish"
+                            },
+                            {
+                              "enum": ["it"],
+                              "title": "Italian",
+                              "description": "Italian"
+                            }
+                          ]
+                        },
+                        "title": {
+                          "type": "string",
+                          "title": "Title",
+                          "description": "Event title. \n Likely to be the first thing displayed on a wallet app.",
+                          "default": ""
+                        },
+                        "description": {
+                          "type": "string",
+                          "title": "Description",
+                          "description": "Description of the Event. \n A description can be stored for each language",
+                          "widget": {
+                            "id": "textarea"
+                          }
+                        },
+                        "externalContents": {
+                          "type": "array",
+                          "title": "External Contents",
+                          "description": "This field is designed to store the links to external contents the Event issuer whish to introduce to the end customer in a wallet app.\n Specific external contents can be stored for each language.",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "title": "Type",
+                                "widget": {
+                                  "id": "select"
+                                },
+                                "oneOf": [
+                                  {
+                                    "enum": ["website"],
+                                    "title": "Website (main)",
+                                    "description": "Website (main)"
+                                  },
+                                  {
+                                    "enum": ["eshop"],
+                                    "title": "Eshop",
+                                    "description": "Eshop"
+                                  },
+                                  {
+                                    "enum": ["other"],
+                                    "title": "other",
+                                    "description": "other"
+                                  }
+                                ]
+                              },
+                              "title": {
+                                "type": "string",
+                                "title": "Title",
+                                "widget": {
+                                  "id": "string"
+                                }
+                              },
+                              "url": {
+                                "type": "string",
+                                "title": "Url",
+                                "widget": {
+                                  "id": "string"
+                                }
+                              },
+                              "order": {
+                                "type": "number",
+                                "title": "Order (number)"
+                              }
+                            }
+                          }
+                        },
+                        "i18n": {
+                          "type": "array",
+                          "title": "Other languages : Title / Description / External contents",
+                          "description": "Events' details in languages different than the default one.",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "language": {
+                                "type": "string",
+                                "title": "Language",
+                                "widget": {
+                                  "id": "select"
+                                },
+                                "oneOf": [
+                                  {
+                                    "enum": ["fr-FR"],
+                                    "title": "French",
+                                    "description": "French"
+                                  },
+                                  {
+                                    "enum": ["en-US"],
+                                    "title": "English (US)",
+                                    "description": "English (US)"
+                                  },
+                                  {
+                                    "enum": ["zh-TW"],
+                                    "title": "Chinese (traditional)",
+                                    "description": "Chinese (traditional)"
+                                  },
+                                  {
+                                    "enum": ["zh-CN"],
+                                    "title": "Chinese (simplified)",
+                                    "description": "Chinese (simplified)"
+                                  },
+                                  {
+                                    "enum": ["ko-KR"],
+                                    "title": "Korean",
+                                    "description": "Korean"
+                                  },
+                                  {
+                                    "enum": ["ja-JP"],
+                                    "title": "Japanese",
+                                    "description": "Japanese"
+                                  },
+                                  {
+                                    "enum": ["de-DE"],
+                                    "title": "German",
+                                    "description": "German"
+                                  },
+                                  {
+                                    "enum": ["es"],
+                                    "title": "Spanish",
+                                    "description": "Spanish"
+                                  },
+                                  {
+                                    "enum": ["it"],
+                                    "title": "Italian",
+                                    "description": "Italian"
+                                  }
+                                ]
+                              },
+                              "title": {
+                                "type": "string",
+                                "title": "Title",
+                                "widget": {
+                                  "id": "textarea"
+                                }
+                              },
+                              "description": {
+                                "type": "string",
+                                "title": "Description",
+                                "description": "Description of the Event. \n A description can be stored for each language",
+                                "widget": {
+                                  "id": "textarea"
+                                }
+                              },
+                              "externalContents": {
+                                "type": "array",
+                                "title": "External Contents",
+                                "description": "This field is designed to store the links to external contents the Event issuer whish to introduce to the end customer in a wallet app.\n Specific external contents can be stored for each language.",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "title": "Type",
+                                      "widget": {
+                                        "id": "select"
+                                      },
+                                      "oneOf": [
+                                        {
+                                          "enum": ["website"],
+                                          "title": "Website (main)",
+                                          "description": "Website (main)"
+                                        },
+                                        {
+                                          "enum": ["eshop"],
+                                          "title": "Eshop",
+                                          "description": "Eshop"
+                                        },
+                                        {
+                                          "enum": ["other"],
+                                          "title": "other",
+                                          "description": "other"
+                                        }
+                                      ]
+                                    },
+                                    "title": {
+                                      "type": "string",
+                                      "title": "Title",
+                                      "widget": {
+                                        "id": "string"
+                                      }
+                                    },
+                                    "url": {
+                                      "type": "string",
+                                      "title": "Url",
+                                      "widget": {
+                                        "id": "string"
+                                      }
+                                    },
+                                    "order": {
+                                      "type": "number",
+                                      "title": "Order (number)"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "medias": {
+                          "type": "array",
+                          "title": "Pictures & Medias",
+                          "description": "Pictures & Medias used to support the presentation of the Event in the wallet app.",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "mediaType": {
+                                "type": "string",
+                                "title": "Media Type",
+                                "widget": {
+                                  "id": "select"
+                                },
+                                "oneOf": [
+                                  {
+                                    "enum": ["picture"],
+                                    "title": "Picture (png / jpg)",
+                                    "description": "Picture (png / jpg)"
+                                  },
+                                  {
+                                    "enum": ["youtube"],
+                                    "title": "Youtube video",
+                                    "description": "Youtube video"
+                                  }
+                                ]
+                              },
+                              "type": {
+                                "type": "string",
+                                "title": "Type",
+                                "widget": {
+                                  "id": "select"
+                                },
+                                "oneOf": [
+                                  {
+                                    "enum": ["product"],
+                                    "title": "Event media / picture",
+                                    "description": "Event media / picture"
+                                  }
+                                ]
+                              },
+                              "url": {
+                                "type": "string",
+                                "title": "URL",
+                                "widget": {
+                                  "id": "string"
+                                }
+                              },
+                              "hash": {
+                                "type": "string",
+                                "title": "Media Hash",
+                                "widget": {
+                                  "id": "string"
+                                }
+                              },
+                              "order": {
+                                "type": "number",
+                                "title": "Media Order (number)"
+                              }
+                            }
+                          }
+                        },
+                        "attributes": {
+                          "type": "array",
+                          "title": "Specific Attributes",
+                          "description": "Information on the specific attributes of the Event.",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "title": "Type",
+                                "widget": {
+                                  "id": "select"
+                                },
+                                "oneOf": [
+                                  {
+                                    "title": "Color",
+                                    "description": "Color",
+                                    "enum": ["color"]
+                                  },
+                                  {
+                                    "title": "Material",
+                                    "description": "Material",
+                                    "enum": ["material"]
+                                  },
+                                  {
+                                    "title": "Printed",
+                                    "description": "Printed",
+                                    "enum": ["printed"]
+                                  }
+                                ]
+                              },
+                              "value": {
+                                "type": "string",
+                                "title": "Value",
+                                "widget": {
+                                  "id": "string"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "valuePrice": {
+                          "type": "string",
+                          "title": "Price",
+                          "default": "",
+                          "description": "Price of the service related to the event, if applicable."
+                        },
+                        "currencyPrice": {
+                          "type": "string",
+                          "title": "Currency",
+                          "default": "",
+                          "description": "Currency",
+                          "widget": {
+                            "id": "select"
+                          },
+                          "oneOf": [
+                            {
+                              "title": "US Dollar",
+                              "description": "US Dollar",
+                              "enum": ["USD"]
+                            },
+                            {
+                              "title": "Euro",
+                              "description": "Euro",
+                              "enum": ["EUR"]
+                            },
+                            {
+                              "title": "Pound",
+                              "description": "Pound",
+                              "enum": ["GBP"]
+                            }
+                          ]
+                        },
+                        "location": {
+                          "type": "string",
+                          "title": "Location",
+                          "description": "Location related to the event, if applicable.",
+                          "default": ""
+                        }
+                      }
+                    },
+                    "address": {
+                      "type": "string",
+                      "title": "Address"
+                    },
+                    "blockNumber": {
+                      "type": "number",
+                      "title": "Block Number"
+                    },
+                    "transactionHash": {
+                      "type": "string",
+                      "title": "Transaction Hash"
+                    },
+                    "transactionIndex": {
+                      "type": "number",
+                      "title": "Transaction Index"
+                    },
+                    "blockHash": {
+                      "type": "string",
+                      "title": "Block Hash"
+                    },
+                    "logIndex": {
+                      "type": "number",
+                      "title": "Log Index"
+                    },
+                    "removed": {
+                      "type": "boolean",
+                      "title": "Removed"
+                    },
+                    "id": {
+                      "type": "string",
+                      "title": "ID"
+                    },
+                    "returnValues": {
+                      "type": "object",
+                      "properties": {
+                        "_eventId": {
+                          "type": "string",
+                          "title": "From"
+                        },
+                        "_sender": {
+                          "type": "string",
+                          "title": "To"
+                        }
+                      }
+                    },
+                    "event": {
+                      "type": "string",
+                      "title": "Event"
+                    },
+                    "signature": {
+                      "type": "string",
+                      "title": "Signature"
+                    },
+                    "raw": {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "string",
+                          "title": "Data"
+                        },
+                        "topics": {
+                          "type": "array",
+                          "title": "Topics",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "issuerSignature": {
+      "type": "string",
+      "title": "Issuer Signature (for full privacy)",
+      "default": "",
+      "description": "Issuer Signature (for full privacy)"
+    },
+    "EAN": {
+      "type": "string",
+      "title": "EAN"
+    },
+    "technicalReference": {
+      "type": "string",
+      "title": "Technical Reference"
+    },
+    "commercialReference": {
+      "type": "string",
+      "title": "Commercial Reference"
+    },
+    "postSaleManufacturerWarrantyPeriod": {
+      "type": "object",
+      "title": "Post Sale Manufacturer Warranty Period",
+      "properties": {
+        "value": { "type": "string", "title": "Value"  },
+        "unit": { "type": "string", "title": "Unit"  }
+      }
+    },
+    "reparabilityIndex": {
+      "type": "object",
+      "title": "Reparability Index",
+      "properties": {
+        "value": { "type": "string", "title": "Value" },
+        "indexDefinitionYear": { "type": "string", "title": "Year Index" }
+      }
+    },
+    "durabilityIndex": {
+      "type": "object",
+      "title": "Durability Index",
+      "properties": {
+        "value": { "type": "string", "title": "Value" },
+        "indexDefinitionYear": { "type": "string", "title": "Year Index" },
+        "scope": { "type": "string", "enum": ["FR", "EU"], "title": "Regulatory Scope" }
+      }
+    },
+    "energyConsumption": {
+      "type": "object",
+      "title": "Energy Consumption",
+      "properties": {
+        "value": { "type": "string", "title": "Quantity" },
+        "unit": { "type": "string", "title": "Unit" },
+        "label": { "type": "string", "title": "Label" }
+      }
+    },
+    "waterConsumption": {
+      "type": "object",
+      "title": "Water Consumption",
+      "properties": {
+        "value": { "type": "string", "title": "Quantity" },
+        "unit": { "type": "string", "title": "Unit" }
+      }
+    },
+    "energyClass": {
+      "type": "object",
+      "title": "Energy Class",
+      "properties": {
+        "value": { "type": "string", "title": "Value"  },
+        "indexDefinitionYear": { "type": "string", "title": "Year Index"  }
+      }
+    },
+    "dangerousSubstance": {
+      "type": "boolean",
+      "title": "Dangerous Substance",
+      "default": false
+    },
+    "recyclabilityMention": {
+      "type": "string",
+      "title": "Recyclability Mention"
+    },
+    "preciousOrCriticalMetals": {
+      "type": "boolean",
+      "title": "Precious or Critical Metals",
+      "default": false
+    },
+    "recycledContent": {
+      "type": "boolean",
+      "title": "Recycled Content",
+      "default": false
+    },
+    "ecoModulation": {
+      "type": "string",
+      "title": "Eco Modulation"
+    },
+    "services": {
+      "type": "array",
+      "title": "Services",
+      "items": {
+        "type": "object",
+        "properties": {
+          "title": { "type": "string", "title": "Title" },
+          "icon": { "type": "string", "title": "Icon" },
+          "url": { "type": "string", "title": "URL" }
+        }
+      }
+    },
+    "externalContent": {
+      "type": "array",
+      "title": "External Content",
+      "items": {
+        "type": "object",
+        "properties": {
+          "title": { "type": "string", "title": "Title" },
+          "icon": { "type": "string", "title": "Icon" },
+          "url": { "type": "string", "title": "URL" }
+        }
+      }
+    },
+    "ecosystem": {
+      "type": "object",
+      "title": "Ecosystem",
+      "properties": {
+        "categorieReglementaire": {
+          "type": "string",
+          "title": "Catégorie Réglementaire"
+        },
+        "secteur": {
+          "type": "string",
+          "title": "Secteur"
+        },
+        "fluxNiveau1": {
+          "type": "string",
+          "title": "Flux Niveau 1"
+        },
+        "fluxNiveau2": {
+          "type": "string",
+          "title": "Flux Niveau 2"
+        },
+        "typeEquipementNiveau1": {
+          "type": "object",
+          "title": "Type Équipement Niveau 1",
+          "properties": {
+            "id": {
+              "type": "string",
+              "title": "ID"
+            },
+            "label": {
+              "type": "string",
+              "title": "Label"
+            }
+          }
+        },
+        "typeEquipementNiveau2": {
+          "type": "object",
+          "title": "Type Équipement Niveau 2",
+          "properties": {
+            "id": {
+              "type": "string",
+              "title": "ID"
+            },
+            "label": {
+              "type": "string",
+              "title": "Label"
+            }
+          }
+        }
+      }
+    }
+  },
+  "required": ["$schema"]
+}

--- a/public/version9/test/imprint/certificate.spec.ts
+++ b/public/version9/test/imprint/certificate.spec.ts
@@ -1,0 +1,24 @@
+import {isObjectMatchingModel} from 'isobjectmatchingmodel';
+import {Arianee, NETWORK} from "@arianee/arianeejs";
+const ArianeeProductCertificate =  require('../../../version9/ArianeeProductCertificate-i18n.json');
+
+describe("version 9", () => {
+    it('should create the same imprint',async ()=>{
+        const expectedHash = '0x63a847a21e4ec8075855c58a8261d81946153f930609f701ef5c16553176f564'
+        const content = {
+            "$schema": "https://cert.arianee.org/version9/ArianeeProductCertificate-i18n.json",
+            "name": "Ma super zoé",
+            "serialnumber": [],
+            "description": "ma description Le Lorem Ips, comme Aldus PageMaker.",
+            "subCategory": "dress",
+            "category": "clothes"
+        }
+
+        const arianee = await new Arianee().init(NETWORK.arianeeTestnet);
+
+        const wallet = arianee.fromRandomMnemonic();
+        const hash = await wallet.utils.cert(ArianeeProductCertificate, content);
+
+        expect(hash).toBe(expectedHash);
+    })
+});


### PR DESCRIPTION
## Summary
- Adds a new `version9` of `ArianeeProductCertificate-i18n.json` as a copy of `version8` with a new `durabilityIndex` field (`value`, `indexDefinitionYear`, `scope: FR | EU`).
- Bumping to a new version preserves imprint compatibility for certificates already emitted with `version8` — modifying `version8` in place would have invalidated their on-chain imprints since `@0xcert/cert` derives the Merkle tree from the schema structure.
- Includes the matching imprint spec for `version9`.

## Test plan
- [x] `npm test` — 15/15 suites, 22/22 tests pass, including the new `public/version9/test/imprint/certificate.spec.ts`
- [x] `public/version8/test/imprint/certificate.spec.ts` still passes (version8 schema untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)