### PR TITLE
feat(version1): add productCore display-fields schema

### DIFF
--- a/public/version1/productCore.json
+++ b/public/version1/productCore.json
@@ -1,0 +1,36 @@
+{
+  "title": "Product Core",
+  "description": "Common display fields shown on every product passport.",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "title": "Commercial name",
+      "description": "Product name shown to end-customers."
+    },
+    "image": {
+      "type": "string",
+      "format": "uri",
+      "title": "Image",
+      "description": "Cover image URL."
+    },
+    "brand": {
+      "type": "string",
+      "title": "Brand"
+    },
+    "category": {
+      "type": "string",
+      "title": "Category"
+    },
+    "sku": {
+      "type": "string",
+      "title": "SKU",
+      "description": "Commercial display SKU, distinct from the business product group id."
+    },
+    "description": {
+      "type": "string",
+      "title": "Description"
+    }
+  },
+  "required": []
+}


### PR DESCRIPTION
Adds `public/version1/productCore.json` — a shared schema for the common product **display fields** (name, image, brand, category, SKU, description).

Consumed by the passport platform as a global "Product Core" data profile (replaces hardcoded core fields with a governed, versioned schema). All fields optional (`required: []`) — non-breaking; `name` may be made required later.

Served at:
`https://raw.githubusercontent.com/Arianee/conventions/refs/heads/main/public/version1/productCore.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)