### PR TITLE
feat(jsonld): publish arianee-product-v1 JSON-LD context (ARI-3434)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,23 @@
 # generate docs
 
 jsonschema2md -d public/version1/ -o ../ArianeeDocs/docs -e json 
+# JSON-LD context (ARI-3434)
+
+`public/contexts/arianee-product-v1.jsonld` — served at `https://cert.arianee.org/contexts/arianee-product-v1.jsonld` — maps the stable fields of the v8/v9 ArianeeProductCertificate schemas to [schema.org](https://schema.org) IRIs (`name`, `description`, `model`, `sku`, `gtin`, `EAN`, `category`, `subBrand`, `manufacturer`, `manufacturingCountry`, `image`, `external_url`).
+
+A certificate becomes machine-interpretable JSON-LD by referencing it — no field renaming needed, unmapped fields are simply ignored by JSON-LD consumers:
+
+```json
+{
+  "@context": "https://cert.arianee.org/contexts/arianee-product-v1.jsonld",
+  "@type": "https://schema.org/Product",
+  "name": "Heritage 24 bag",
+  "gtin": "03700123456789",
+  "manufacturingCountry": "FRA"
+}
+```
+
+Rules:
+- A published context is **immutable** (consumers cache it; changing a mapping silently changes the meaning of existing documents). To change a mapping, publish `arianee-product-v2.jsonld`.
+- Only map fields whose schema.org equivalent is unambiguous. Regulatory fields (`reparabilityIndex`, `energyClass`, `recycledContent`, …) are deliberately NOT mapped — the ESPR/CEN-CENELEC vocabularies are not frozen yet.
+- `public/contexts/test/context.spec.ts` guards that every mapped key exists in both v8 and v9 schemas.

--- a/firebase.json
+++ b/firebase.json
@@ -34,6 +34,19 @@
         ]
       },
       {
+        "source": "**/*.jsonld",
+        "headers": [
+          {
+            "key": "Content-Type",
+            "value": "application/ld+json"
+          },
+          {
+            "key": "Access-Control-Allow-Origin",
+            "value": "*"
+          }
+        ]
+      },
+      {
         "source": "cert/*.json",
         "headers": [
           {

--- a/public/contexts/arianee-product-v1.jsonld
+++ b/public/contexts/arianee-product-v1.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "schema": "https://schema.org/",
+    "name": "schema:name",
+    "description": "schema:description",
+    "model": "schema:model",
+    "sku": "schema:sku",
+    "gtin": "schema:gtin",
+    "EAN": "schema:gtin13",
+    "category": "schema:category",
+    "subBrand": "schema:brand",
+    "manufacturer": "schema:manufacturer",
+    "manufacturingCountry": "schema:countryOfOrigin",
+    "image": { "@id": "schema:image", "@type": "@id" },
+    "external_url": { "@id": "schema:url", "@type": "@id" }
+  }
+}

--- a/public/contexts/arianee-product-v1.jsonld
+++ b/public/contexts/arianee-product-v1.jsonld
@@ -1,17 +1,17 @@
 {
+  "comment": "JSON-LD context for Arianee product certificates (v8/v9 schemas). This file is a translation dictionary: it maps our certificate field names (left) to globally-published schema.org concepts (right), so that any machine that doesn't know Arianee can still understand our data. A certificate becomes machine-interpretable JSON-LD by adding a single line: \"@context\": \"https://cert.arianee.org/contexts/arianee-product-v1.jsonld\". Fields not listed here are simply ignored by JSON-LD consumers. This file is NOT a schema (the v8/v9 JSON Schemas validate the SHAPE of a cert; this file declares the MEANING of its fields). Once published it is immutable: to change a mapping, publish arianee-product-v2.jsonld. This 'comment' key is ignored by JSON-LD processors, which only read '@context'. See ARI-3434.",
   "@context": {
-    "schema": "https://schema.org/",
-    "name": "schema:name",
-    "description": "schema:description",
-    "model": "schema:model",
-    "sku": "schema:sku",
-    "gtin": "schema:gtin",
-    "EAN": "schema:gtin13",
-    "category": "schema:category",
-    "subBrand": "schema:brand",
-    "manufacturer": "schema:manufacturer",
-    "manufacturingCountry": "schema:countryOfOrigin",
-    "image": { "@id": "schema:image", "@type": "@id" },
-    "external_url": { "@id": "schema:url", "@type": "@id" }
+    "name": "https://schema.org/name",
+    "description": "https://schema.org/description",
+    "model": "https://schema.org/model",
+    "sku": "https://schema.org/sku",
+    "gtin": "https://schema.org/gtin",
+    "EAN": "https://schema.org/gtin13",
+    "category": "https://schema.org/category",
+    "subBrand": "https://schema.org/brand",
+    "manufacturer": "https://schema.org/manufacturer",
+    "manufacturingCountry": "https://schema.org/countryOfOrigin",
+    "image": { "@id": "https://schema.org/image", "@type": "@id" },
+    "external_url": { "@id": "https://schema.org/url", "@type": "@id" }
   }
 }

--- a/public/contexts/test/context.spec.ts
+++ b/public/contexts/test/context.spec.ts
@@ -9,7 +9,7 @@ const v9 = require('../../version9/ArianeeProductCertificate-i18n.json');
 
 describe('arianee-product-v1 JSON-LD context', () => {
     const terms: [string, unknown][] = Object.entries(context['@context']).filter(
-        ([key]) => !key.startsWith('@') && key !== 'schema'
+        ([key]) => !key.startsWith('@')
     );
 
     it('should only map properties that exist in the v8 and v9 certificate schemas', () => {
@@ -20,10 +20,9 @@ describe('arianee-product-v1 JSON-LD context', () => {
     });
 
     it('should map every term to a schema.org IRI', () => {
-        expect(context['@context']['schema']).toBe('https://schema.org/');
         for (const [, value] of terms) {
             const iri = typeof value === 'string' ? value : (value as { '@id': string })['@id'];
-            expect(iri.startsWith('schema:')).toBe(true);
+            expect(iri.startsWith('https://schema.org/')).toBe(true);
         }
     });
 });

--- a/public/contexts/test/context.spec.ts
+++ b/public/contexts/test/context.spec.ts
@@ -1,0 +1,29 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+const context = JSON.parse(
+    fs.readFileSync(path.join(__dirname, '../arianee-product-v1.jsonld'), 'utf8')
+);
+const v8 = require('../../version8/ArianeeProductCertificate-i18n.json');
+const v9 = require('../../version9/ArianeeProductCertificate-i18n.json');
+
+describe('arianee-product-v1 JSON-LD context', () => {
+    const terms: [string, unknown][] = Object.entries(context['@context']).filter(
+        ([key]) => !key.startsWith('@') && key !== 'schema'
+    );
+
+    it('should only map properties that exist in the v8 and v9 certificate schemas', () => {
+        for (const [key] of terms) {
+            expect(v8.properties).toHaveProperty(key);
+            expect(v9.properties).toHaveProperty(key);
+        }
+    });
+
+    it('should map every term to a schema.org IRI', () => {
+        expect(context['@context']['schema']).toBe('https://schema.org/');
+        for (const [, value] of terms) {
+            const iri = typeof value === 'string' ? value : (value as { '@id': string })['@id'];
+            expect(iri.startsWith('schema:')).toBe(true);
+        }
+    });
+});


### PR DESCRIPTION
## Quoi

Publie un context JSON-LD officiel pour les certificats produit Arianee : `public/contexts/arianee-product-v1.jsonld`, servi sur `https://cert.arianee.org/contexts/arianee-product-v1.jsonld`.

Il mappe les champs **stables** des schémas v8/v9 vers schema.org : `name`, `description`, `model`, `sku`, `gtin`, `EAN`, `category`, `subBrand`, `manufacturer`, `manufacturingCountry`, `image`, `external_url`.

## Pourquoi

ARI-3434 (veille JSON-LD). Un certificat qui référence ce context devient du JSON-LD interprétable par n'importe quel consommateur sémantique (DPP/ESPR, GS1, schema.org) **sans renommer un seul champ** — les champs non mappés sont simplement ignorés. Non cassant.

Les champs réglementaires (`reparabilityIndex`, `energyClass`, `recycledContent`…) sont volontairement exclus : les vocabulaires ESPR/CEN-CENELEC ne sont pas figés (suivi : ARI-3471).

## Points d'attention

- **Un context publié est immuable** (les consommateurs le cachent ; changer un mapping change le sens des docs existants). Toute évolution = `arianee-product-v2.jsonld`.
- Header Firebase ajouté : `*.jsonld` servi en `application/ld+json`.
- Test jest : chaque clé mappée doit exister dans les schémas v8 ET v9.

## Comment tester

```bash
npx jest public/contexts/test/context.spec.ts
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)